### PR TITLE
debugging empty catalogs during source insertion testing

### DIFF
--- a/nemo/catalogs.py
+++ b/nemo/catalogs.py
@@ -179,7 +179,7 @@ def makeOptimalCatalog(catalogDict, constraintsList = []):
         mergedCatalog.sort(['RADeg', 'decDeg'])
         mergedCatalog=selectFromCatalog(mergedCatalog, constraintsList)
     else:
-        mergedCatalog=[]
+        mergedCatalog=atpy.Table(names=('SNR','RADeg','decDeg'))
     
     return mergedCatalog
 

--- a/nemo/pipelines.py
+++ b/nemo/pipelines.py
@@ -103,7 +103,8 @@ def filterMapsAndMakeCatalogs(config, rootOutDir = None, copyFilters = False, me
             mapDict['surveyMask']=None
             config.unfilteredMapsDictList=[mapDict]
             catalog=_filterMapsAndMakeCatalogs(config, verbose = False, writeAreaMasks = False)
-            catalog, numDuplicatesFound, names=catalogs.removeDuplicates(catalog)       
+            if len(catalog) > 0 :
+                catalog, numDuplicatesFound, names=catalogs.removeDuplicates(catalog)
             pass1CatalogsList.append(catalog)
 
         # Pass 2 - subtract point sources in the maps used for noise term in filter only


### PR DESCRIPTION
Making sure that an empty catalog is of type astropy.Table with the columns expected but subsequent processing, and that nemo doesn't try to remove duplicates from an empty table.